### PR TITLE
add vscode project settings to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -315,3 +315,6 @@ exportcontrol/public/static/
 
 # Mac DS_Store files
 .DS_Store
+
+# VSCode project settings
+.vscode


### PR DESCRIPTION
### Changes

- add `.vscode` to gitignore, the folder used by VSCode for per-project settings