### PR TITLE
update csrf settings to align with safetec repo

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -17,9 +17,12 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 DEBUG = os.getenv("DEBUG", "false") == "true"
 
 AZURE_WEBSITE_HOSTNAME = os.getenv("WEBSITE_HOSTNAME")
-
 ALLOWED_HOSTS = ["localhost", "127.0.0.1"] + ([AZURE_WEBSITE_HOSTNAME] if AZURE_WEBSITE_HOSTNAME is not None else [])
+
 INTERNAL_IPS = ["127.0.0.1"]
+
+CSRF_TRUSTED_ORIGINS_ENV = os.getenv("CSRF_TRUSTED_ORIGINS")
+CSRF_TRUSTED_ORIGINS = CSRF_TRUSTED_ORIGINS_ENV.split(",") if CSRF_TRUSTED_ORIGINS_ENV is not None else []
 
 INSTALLED_APPS = [
     "jazzmin",


### PR DESCRIPTION
### Changes

- add `CSRF_TRUSTED_ORIGINS` from env in django settings

### Rationale

After forking [`safetecnordic/export-control`](https://github.com/safetecnordic/export-control) for Safetec's deployment, we discovered that our CSRF config did not work in production. We already updated it in that repo - this PR updates it in this repo as well, to keep it aligned with the fork.