### PR TITLE
add loading of `ALLOWED_HOSTS` from env

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -16,13 +16,13 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 
 DEBUG = os.getenv("DEBUG", "false") == "true"
 
-AZURE_WEBSITE_HOSTNAME = os.getenv("WEBSITE_HOSTNAME")
-ALLOWED_HOSTS = ["localhost", "127.0.0.1"] + ([AZURE_WEBSITE_HOSTNAME] if AZURE_WEBSITE_HOSTNAME is not None else [])
-
-INTERNAL_IPS = ["127.0.0.1"]
+ALLOWED_HOSTS_ENV = os.getenv("ALLOWED_HOSTS")
+ALLOWED_HOSTS = ["localhost", "127.0.0.1"] + ALLOWED_HOSTS_ENV.split(",") if ALLOWED_HOSTS_ENV is not None else []
 
 CSRF_TRUSTED_ORIGINS_ENV = os.getenv("CSRF_TRUSTED_ORIGINS")
 CSRF_TRUSTED_ORIGINS = CSRF_TRUSTED_ORIGINS_ENV.split(",") if CSRF_TRUSTED_ORIGINS_ENV is not None else []
+
+INTERNAL_IPS = ["127.0.0.1"]
 
 INSTALLED_APPS = [
     "jazzmin",


### PR DESCRIPTION
### Changes

- load `ALLOWED_HOSTS` env in django settings to set `ALLOWED_HOSTS` variable

### Rationale

Safetec has set up a custom domain for the app ([exportcontrol.safetec.no](https://exportcontrol.safetec.no/)). However, Azure's `WEBSITE_HOSTNAME` env variable remains as `exportcontrol-app.azurewebsites.net`. Since we use this env for setting the `ALLOWED_HOSTS` variable, the website now fails with HTTP error 400, because `exportcontrol.safetec.no` is not in `ALLOWED_HOSTS`. This PR loads a custom env variable for setting `ALLOWED_HOSTS`, like we do for `CSRF_TRUSTED_ORIGINS`.